### PR TITLE
AGR-2528 neo4j_env dockerhub => ECR code-changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 REG := 100225593120.dkr.ecr.us-east-1.amazonaws.com
+VERSION := latest
 
 registry-docker-login:
 ifneq ($(shell echo ${REG} | egrep "ecr\..+\.amazonaws\.com"),)
@@ -11,19 +12,19 @@ endif
 endif
 
 all:
-	docker build -t ${REG}/agr_neo4j_env .
+	docker build -t ${REG}/agr_neo4j_env:${VERSION} .
 
 push: registry-docker-login
-	docker push ${REG}/agr_neo4j_env
+	docker push ${REG}/agr_neo4j_env:${VERSION}
 
 pull: registry-docker-login
-	docker pull ${REG}/agr_neo4j_env
+	docker pull ${REG}/agr_neo4j_env:${VERSION}
 
 bash:
-	docker run -t -i ${REG}/agr_neo4j_env bash
+	docker run -t -i ${REG}/agr_neo4j_env:${VERSION} bash
 
 run:
-	docker run -p 7474:7474 -p 7687:7687 -e NEO4J_dbms_memory_heap_maxSize=8g ${REG}/agr_neo4j_env
+	docker run -p 7474:7474 -p 7687:7687 -e NEO4J_dbms_memory_heap_maxSize=8g ${REG}/agr_neo4j_env:${VERSION}
 
 docker-data-pull:
 	docker pull agrdocker/agr_neo4j_qc_data_image

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,29 @@
+REG := 100225593120.dkr.ecr.us-east-1.amazonaws.com
+
+registry-docker-login:
+ifneq ($(shell echo ${REG} | egrep "ecr\..+\.amazonaws\.com"),)
+	@$(eval DOCKER_LOGIN_CMD=aws)
+ifneq (${AWS_PROFILE},)
+	@$(eval DOCKER_LOGIN_CMD=${DOCKER_LOGIN_CMD} --profile ${AWS_PROFILE})
+endif
+	@$(eval DOCKER_LOGIN_CMD=${DOCKER_LOGIN_CMD} ecr get-login-password | docker login -u AWS --password-stdin https://${REG})
+	${DOCKER_LOGIN_CMD}
+endif
+
 all:
-	docker build -t agrdocker/agr_neo4j_env .
+	docker build -t ${REG}/agr_neo4j_env .
 
-push:
-	docker push agrdocker/agr_neo4j_env
+push: registry-docker-login
+	docker push ${REG}/agr_neo4j_env
 
-pull:
-	docker pull agrdocker/agr_neo4j_env
+pull: registry-docker-login
+	docker pull ${REG}/agr_neo4j_env
 
 bash:
-	docker run -t -i agrdocker/agr_neo4j_env bash
+	docker run -t -i ${REG}/agr_neo4j_env bash
 
 run:
-	docker run -p 7474:7474 -p 7687:7687 -e NEO4J_dbms_memory_heap_maxSize=8g agrdocker/agr_neo4j_env
+	docker run -p 7474:7474 -p 7687:7687 -e NEO4J_dbms_memory_heap_maxSize=8g ${REG}/agr_neo4j_env
 
 docker-data-pull:
 	docker pull agrdocker/agr_neo4j_qc_data_image

--- a/Makefile
+++ b/Makefile
@@ -25,9 +25,3 @@ bash:
 
 run:
 	docker run -p 7474:7474 -p 7687:7687 -e NEO4J_dbms_memory_heap_maxSize=8g ${REG}/agr_neo4j_env:${VERSION}
-
-docker-data-pull:
-	docker pull agrdocker/agr_neo4j_qc_data_image
-
-docker-data-run:
-	docker run -p 7474:7474 -p 7687:7687 -e NEO4J_dbms_memory_heap_maxSize=8g agrdocker/agr_neo4j_qc_data_image

--- a/README.md
+++ b/README.md
@@ -16,22 +16,22 @@ After a version has been created the user should create a tagged docker containe
 make all VERSION=<version>
 make push VERSION=<version>
 ```
-This will make it so that there is a agr_neo4j_env container available via DockerHub. If you would like to use this version feel free to specify the version in the agr_neo4j's Dockerfile. The agr_loader Dockerfile should specify a specific version when pushing code to develop. This way we will know exactly what is running in dev, staging and production environments.  
+This will make it so that there is a agr_neo4j_env container available via ECR (by default). If you would like to use this version feel free to specify the version in the agr_neo4j's Dockerfile. The agr_loader Dockerfile should specify a specific version when pushing code to develop. This way we will know exactly what is running in dev, staging and production environments.  
 
 In order to make changes and test them you might want to create a "develop" container. To do this you can use commands available in the Makefile:
 
-*These are commands done on the development machine. If you are developing locally feel free to use the commands but don't push to DockerHub
+*These are commands done on the development machine. If you are developing locally feel free to use the commands but don't push to ECR
 
 ## Bulding develop container
 ```bash
 make all
 ```
-## Share by pushing to DockerHub
+## Share by pushing to container registry
 ```bash
 make push
 ```
 
-## Using develop container on Dockerhub
+## Using develop container from container registry
 ```bash
 make pull
 ```

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ git hf release finish <version>
 After a version has been created the user should create a tagged docker container with the following command
 
 ```bash
-docker build -t agrdocker/agr_neo4j_env:<version> .
-docker docker push agrdocker/agr_neo4j_env:<version>
+make all VERSION=<version>
+make push VERSION=<version>
 ```
 This will make it so that there is a agr_neo4j_env container available via DockerHub. If you would like to use this version feel free to specify the version in the agr_neo4j's Dockerfile. The agr_loader Dockerfile should specify a specific version when pushing code to develop. This way we will know exactly what is running in dev, staging and production environments.  
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ In order to make changes and test them you might want to create a "develop" cont
 
 *These are commands done on the development machine. If you are developing locally feel free to use the commands but don't push to ECR
 
-## Bulding develop container
+## Building develop container
 ```bash
 make all
 ```


### PR DESCRIPTION
Makefile updates done to move away from dockerhub and into ECR as our docker image registry (analogous to alliance-genome/agr_ansible_devops#15) + deprecated `agr_neo4j_qc_data_image` image usage removal + matching README update.